### PR TITLE
FEAT: Add quick exit support to menus

### DIFF
--- a/Installers/installer.sh
+++ b/Installers/installer.sh
@@ -20,6 +20,7 @@ EXIT_APP_CODE=42
 
 trap 'echo -e "\n${GREEN}Goodbye!${NC}"; exit $EXIT_APP_CODE' INT
 
+# print_centered centers the given text within UI_WIDTH using an optional color and prints a single padded line.
 print_centered() {
     local text="$1"
     local color="${2:-$NC}"
@@ -28,22 +29,29 @@ print_centered() {
     printf "${color}%${padding}s%s${NC}\n" "" "$text"
 }
 
+# print_line prints a horizontal line of length UI_WIDTH using the specified character (default '=') and color (default $BLUE).
 print_line() {
     local char="${1:-=}"
     local color="${2:-$BLUE}"
     printf "${color}%${UI_WIDTH}s${NC}\n" "" | sed "s/ /${char}/g"
 }
 
+# print_status prints an informational message prefixed with a cyan "[INFO]" tag.
 print_status() { echo -e "${CYAN}[INFO]${NC} $1"; }
+# print_success prints the given message prefixed with a green `[OK]` tag to stdout.
 print_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+# print_warn prints a warning message prefixed with a yellow "[WARN]" tag.
 print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+# print_error prints MESSAGE to stdout prefixed with a red '[ERROR]' tag.
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
+# pause prints a blank line and waits for the user to press Enter to return to the menu.
 pause() {
     echo ""
     read -rp "Press [Enter] to return to the menu..."
 }
 
+# truncate_string truncates a string to max_len characters (including a trailing '..' when truncated) and echoes the result.
 truncate_string() {
     local str="$1"
     local max_len="$2"
@@ -54,10 +62,12 @@ truncate_string() {
     fi
 }
 
+# get_current_branch prints the current Git branch name or "unknown" if the branch cannot be determined.
 get_current_branch() {
     git branch --show-current 2>/dev/null || echo "unknown"
 }
 
+# show_header clears the screen and prints the stylized ASCII art header, a centered title, and a decorative line.
 show_header() {
     clear
     echo -e "${BLUE}███████╗██╗   ██╗███████╗████████╗███████╗███╗   ███╗    ███████╗███████╗████████╗██╗   ██╗██████╗ ${NC}"
@@ -70,6 +80,8 @@ show_header() {
     print_line "=" "$BLUE"
 }
 
+# show_stats prints a formatted system information panel to stdout.
+# It displays OS, kernel, hostname, IP/subnet/gateway, load average, memory and disk usage, uptime, and the current Git branch.
 show_stats() {
     local distro="Unknown"
     if [ -f /etc/os-release ]; then
@@ -179,6 +191,7 @@ declare -A INSTALLERS=(
 
 TOTAL_OPTIONS=${#INSTALLERS[@]}
 
+# execute_installer validates and runs an installer script (first arg: script path, second arg: display name), reports non-zero exit codes, and prompts the user to continue, return to the main menu, or quit.
 execute_installer() {
     local script_name="$1"
     local display_name="$2"
@@ -238,6 +251,7 @@ execute_installer() {
     esac
 }
 
+# show_menu displays the available installers in two columns (keys 1–6) and prints options to return to the main menu (0) or exit (q).
 show_menu() {
     echo -e "${WHITE}AVAILABLE INSTALLERS${NC}"
 

--- a/Installers/serverConfig.sh
+++ b/Installers/serverConfig.sh
@@ -272,30 +272,25 @@ while true; do
 
     read -rp "  Enter selection [0-$TOTAL_OPTIONS, b, q]: " choice
 
-    case "$choice" in
-        [0-9])
-            if [[ "$choice" =~ ^[1-9][0-9]*$ ]] && [ -n "${CONFIG_SCRIPTS[$choice]:-}" ]; then
-                script="${CONFIG_SCRIPTS[$choice]%%:*}"
-                name="${CONFIG_SCRIPTS[$choice]#*:}"
-                execute_config "$script" "$name"
-            else
-                print_error "Invalid option."
-                sleep 1
-            fi
-            ;;
-        0|b|back)
-            echo -e "\n${GREEN}Returning to Main Menu...${NC}"
-            exit 0
-            ;;
-        q|qq|exit)
-            echo -e "\n${GREEN}Goodbye!${NC}"
-            exit $EXIT_APP_CODE
-            ;;
-        "")
-            ;;
-        *)
+    if [[ -z "$choice" ]]; then
+        continue
+    elif [[ "$choice" =~ ^(0|b|back)$ ]]; then
+        echo -e "\n${GREEN}Returning to Main Menu...${NC}"
+        exit 0
+    elif [[ "$choice" =~ ^(q|qq|exit)$ ]]; then
+        echo -e "\n${GREEN}Goodbye!${NC}"
+        exit $EXIT_APP_CODE
+    elif [[ "$choice" =~ ^[1-9][0-9]*$ ]]; then
+        if [ -n "${CONFIG_SCRIPTS[$choice]:-}" ]; then
+            script="${CONFIG_SCRIPTS[$choice]%%:*}"
+            name="${CONFIG_SCRIPTS[$choice]#*:}"
+            execute_config "$script" "$name"
+        else
             print_error "Invalid option: $choice"
             sleep 1
-            ;;
-    esac
+        fi
+    else
+        print_error "Invalid option: $choice"
+        sleep 1
+    fi
 done

--- a/Installers/serverConfig.sh
+++ b/Installers/serverConfig.sh
@@ -224,6 +224,11 @@ execute_config() {
     local exit_code=$?
     set -e
 
+    if [ $exit_code -eq $EXIT_APP_CODE ]; then
+       echo -e "\n${GREEN}Goodbye!${NC}"
+       exit $EXIT_APP_CODE
+    fi
+
     echo ""
     print_line "-" "$BLUE"
 
@@ -265,7 +270,7 @@ while true; do
     show_stats
     show_menu
 
-    read -rp "  Enter selection [0-$TOTAL_OPTIONS, q]: " choice
+    read -rp "  Enter selection [0-$TOTAL_OPTIONS, b, q]: " choice
 
     case "$choice" in
         [1-9])

--- a/Installers/serverConfig.sh
+++ b/Installers/serverConfig.sh
@@ -273,8 +273,8 @@ while true; do
     read -rp "  Enter selection [0-$TOTAL_OPTIONS, b, q]: " choice
 
     case "$choice" in
-        [1-9])
-            if [ -n "${CONFIG_SCRIPTS[$choice]:-}" ]; then
+        [0-9])
+            if [[ "$choice" =~ ^[1-9][0-9]*$ ]] && [ -n "${CONFIG_SCRIPTS[$choice]:-}" ]; then
                 script="${CONFIG_SCRIPTS[$choice]%%:*}"
                 name="${CONFIG_SCRIPTS[$choice]#*:}"
                 execute_config "$script" "$name"

--- a/Installers/serverConfig.sh
+++ b/Installers/serverConfig.sh
@@ -20,6 +20,7 @@ EXIT_APP_CODE=42
 
 trap 'echo -e "\n${GREEN}Goodbye!${NC}"; exit $EXIT_APP_CODE' INT
 
+# print_centered centers the given text within UI_WIDTH and prints it using the optional ANSI color (defaults to no color).
 print_centered() {
     local text="$1"
     local color="${2:-$NC}"
@@ -28,22 +29,29 @@ print_centered() {
     printf "${color}%${padding}s%s${NC}\n" "" "$text"
 }
 
+# print_line prints a horizontal line of length $UI_WIDTH composed of the given character (default `=`) using the specified color (default `$BLUE`).
 print_line() {
     local char="${1:-=}"
     local color="${2:-$BLUE}"
     printf "${color}%${UI_WIDTH}s${NC}\n" "" | sed "s/ /${char}/g"
 }
 
+# print_status prints a message prefixed with `[INFO]` in cyan color.
 print_status() { echo -e "${CYAN}[INFO]${NC} $1"; }
+# print_success prints a green "[OK]" status tag followed by the given message.
 print_success() { echo -e "${GREEN}[OK]${NC} $1"; }
+# print_warn prints a warning message prefixed with "[WARN]" in yellow followed by the provided message to stdout.
 print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+# print_error prints an "[ERROR]" label in red followed by the provided message.
 print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
+# pause prompts the user to press Enter to return to the menu and waits for input.
 pause() {
     echo ""
     read -rp "Press [Enter] to return to the menu..."
 }
 
+# truncate_string truncates a string to a maximum length and appends ".." when the original exceeds that length.
 truncate_string() {
     local str="$1"
     local max_len="$2"
@@ -54,10 +62,12 @@ truncate_string() {
     fi
 }
 
+# get_current_branch returns the current Git branch name or "unknown" if it cannot be determined.
 get_current_branch() {
     git branch --show-current 2>/dev/null || echo "unknown"
 }
 
+# show_header clears the terminal and prints a stylized "SERVER CONFIGURATION" banner with a centered subtitle and a separator line.
 show_header() {
     clear
     echo -e "${BLUE}███████╗██╗   ██╗███████╗████████╗███████╗███╗   ███╗    ███████╗███████╗████████╗██╗   ██╗██████╗ ${NC}"
@@ -70,6 +80,7 @@ show_header() {
     print_line "=" "$BLUE"
 }
 
+# show_stats displays a formatted SYSTEM INFORMATION block including OS, kernel, hostname, load average, memory and disk usage, uptime, IP/subnet/gateway, and current git branch.
 show_stats() {
     local distro="Unknown"
     if [ -f /etc/os-release ]; then
@@ -174,6 +185,7 @@ declare -A CONFIG_SCRIPTS=(
 
 TOTAL_OPTIONS=${#CONFIG_SCRIPTS[@]}
 
+# execute_config validates and runs a configuration script (making it executable on request), captures its exit code, and prompts the user to continue, return to the main menu, or quit.
 execute_config() {
     local script_name="$1"
     local display_name="$2"
@@ -233,6 +245,7 @@ execute_config() {
     esac
 }
 
+# show_menu prints the configuration options menu, listing each entry from CONFIG_SCRIPTS with numbered options and showing a "Return to Main Menu" (0) and "Exit" (q) choice.
 show_menu() {
     echo -e "${WHITE}CONFIGURATION OPTIONS${NC}"
 

--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,9 @@ WHITE='\033[1;37m'
 NC='\033[0m'
 
 UI_WIDTH=86
-SCRIPT_VERSION="3.6.1"
+SCRIPT_VERSION="3.6.2"
 CHECKSUM_FILE="$SCRIPT_DIR/Installers/.checksums.sha256"
+EXIT_APP_CODE=42
 
 # --- 3. SETTINGS & CONFIGURATION ---
 SETTINGS_FILE="$SCRIPT_DIR/settings.conf"
@@ -864,10 +865,15 @@ execute_script() {
                 print_status "Executing with sudo..."
                 echo -e "${GREEN}>>> Executing: $script_name (as root)${NC}"
                 sleep 0.5
-                sudo bash "$full_path"
-                pause
-                set -e
-                return 0
+                bash "$full_path"
+                local script_exit=$?
+                 if [[ $script_exit -eq $EXIT_APP_CODE ]]; then
+                     echo -e "\n${GREEN}Goodbye!${NC}"
+                 exit 0
+                 fi
+                 pause
+                 set -e
+                 return 0
                 ;;
             2)
                 print_warn "Running without root - some operations may fail."
@@ -887,8 +893,12 @@ execute_script() {
 
     echo -e "${GREEN}>>> Executing: $script_name${NC}"
     sleep 0.5
-
     bash "$full_path"
+    local script_exit=$?
+     if [[ $script_exit -eq $EXIT_APP_CODE ]]; then
+       echo -e "\n${GREEN}Goodbye!${NC}"
+     exit 0
+     fi
     pause
     set -e
     return 0

--- a/install.sh
+++ b/install.sh
@@ -697,7 +697,7 @@ parse_script_metadata() {
     head -n 20 "$script_path" 2>/dev/null | grep -i "^# *${key}:" | head -n 1 | sed "s/^# *${key}: *//i" || echo ""
 }
 
-# verify_script_checksum Verifies a script's sha256 checksum from CHECKSUM_FILE and prompts the user on missing or mismatched entries.
+# verify_script_checksum Verifies a script's SHA-256 checksum against CHECKSUM_FILE, prompts the user if the checksum is missing or does not match, and returns 0 if verification is accepted (or skipped) or 1 if the user declines to continue.
 verify_script_checksum() {
     local script_path="$1"
     local script_name
@@ -739,7 +739,7 @@ verify_script_checksum() {
     return 0
 }
 
-# generate_checksums generates SHA-256 checksums for all scripts in Installers/ and writes them to CHECKSUM_FILE.
+# generate_checksums generates SHA-256 checksums for all shell scripts in Installers/ and writes them to CHECKSUM_FILE; accepts an optional "silent" argument to suppress output and returns 0 on success or a non-zero status if the Installers directory is missing, sha256sum is unavailable, or no scripts were found.
 generate_checksums() {
     local silent="${1:-}"
     local installers_dir="$SCRIPT_DIR/Installers"
@@ -778,7 +778,7 @@ generate_checksums() {
     return 0
 }
 
-# execute_script executes an installer from Installers/, verifying existence/readability and file type, validating checksum, ensuring executability, honoring REQUIRES_ROOT, printing an optional DESCRIPTION, running the script, and checking for exit code 42 to exit the entire application.
+# execute_script executes an installer script from Installers/, verifying existence, readability, and file type; validating its SHA-256 checksum; ensuring it is executable; honoring a REQUIRES_ROOT metadata flag (prompting to run with sudo, run anyway, or cancel) and detecting common root-requiring commands; printing DESCRIPTION metadata when present; running the script; and if the script exits with code 42, printing a goodbye message and terminating the entire application.
 execute_script() {
     set +e
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menus now show an explicit Exit option and offer Continue / Back / Quit after running installers.
  * Installers validate scripts before running, offer to fix executable permissions, and capture script results to control navigation.

* **Improvements**
  * Ctrl-C and quit paths consistently terminate the app.
  * Prompts and menu ranges clarified, checksum generation supports a quieter mode, and installer version bumped.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->