### PR TITLE
Core Refactor / create INSTALL_DIR before extraction, add PHP 8.4/8.5 support for WordPress Script

### DIFF
--- a/Installers/WordPress.sh
+++ b/Installers/WordPress.sh
@@ -311,7 +311,7 @@ validate_domain() {
 
 # generate_password generates a 16-character random password from a cryptographically secure source.
 generate_password() {
-    openssl rand -base64 32 | tr -d '=' | cut -c1-16
+    openssl rand -base64 48 | tr -dc 'A-Za-z0-9' | cut -c1-16
 }
 
 # get_database_version prints the MySQL/MariaDB server version string to stdout, or `unknown` if the version cannot be determined.

--- a/Installers/WordPress.sh
+++ b/Installers/WordPress.sh
@@ -599,8 +599,8 @@ elif is_rhel_based || is_arch_based; then
     sed -i 's/^#LoadModule proxy_fcgi_module/LoadModule proxy_fcgi_module/' "$APACHE_CONF" 2>/dev/null || true
 elif is_suse_based; then
     a2enmod rewrite >/dev/null 2>&1 || true
-    a2enmod ssl >/dev/null 2>&1 || true
-    a2enmod php"${PHP_VERSION//./}" >/dev/null 2>&1 || true
+    a2enmod ssl    >/dev/null 2>&1 || true
+    a2enmod php8   >/dev/null 2>&1 || true
 fi
 
 print_success "Web server modules enabled."

--- a/Installers/WordPress.sh
+++ b/Installers/WordPress.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # REQUIRES_ROOT: true
 # DESCRIPTION: Installs WordPress with Apache, MariaDB/MySQL, PHP, and SSL certificates
 
-VERSION="2.0.1"
+VERSION="2.0.2"
 INSTALL_DIR="/var/www/html"
 CREDS_FILE="/root/.wp-creds"
 LOG_FILE="/var/log/wordpress-install.log"
@@ -210,19 +210,19 @@ get_available_php_versions() {
     local versions=()
     
     if is_debian_based; then
-        versions+=($(apt-cache search --names-only '^php[0-9]+$' 2>/dev/null | awk '{print $1}' | sed 's/php//' | sort -V | tail -5))
+        versions+=($(apt-cache search --names-only '^php[0-9]+\.[0-9]+$' 2>/dev/null | awk '{print $1}' | sed 's/php//' | sort -V | tail -7))
     elif is_rhel_based; then
-        versions+=($(dnf module list php 2>/dev/null | grep -E '^\s+php' | awk '{print $1}' | sed 's/php://' | sort -V | tail -5))
+        versions+=($(dnf module list php 2>/dev/null | grep -E '^\s+php' | awk '{print $1}' | sed 's/php://' | sort -V | tail -7))
     elif is_arch_based; then
         if pacman -Qs php &>/dev/null; then
             versions+=("$(pacman -Q php 2>/dev/null | awk '{print $2}' | cut -d- -f1)")
         else
-            versions+=("8.3" "8.2" "8.1")
+            versions+=("8.5" "8.4" "8.3" "8.2" "8.1")
         fi
     fi
     
     if [[ ${#versions[@]} -eq 0 ]]; then
-        versions=("8.3" "8.2" "8.1" "8.0" "7.4")
+        versions=("8.5" "8.4" "8.3" "8.2" "8.1" "8.0" "7.4")
     fi
     
     printf '%s\n' "${versions[@]}"

--- a/install.sh
+++ b/install.sh
@@ -284,13 +284,13 @@ get_os_info() {
     if [[ -f /etc/os-release ]]; then
         case "$info_type" in
             id)
-                grep -Po '(?<=^ID=).+' /etc/os-release 2>/dev/null | tr -d '"' || echo ""
+                sed -n 's/^ID=//p' /etc/os-release 2>/dev/null | tr -d '"' || echo ""
                 ;;
             version_id)
-                grep -Po '(?<=^VERSION_ID=).+' /etc/os-release 2>/dev/null | tr -d '"' || echo ""
+                sed -n 's/^VERSION_ID=//p' /etc/os-release 2>/dev/null | tr -d '"' || echo ""
                 ;;
             pretty_name)
-                grep -Po '(?<=^PRETTY_NAME=).+' /etc/os-release 2>/dev/null | tr -d '"' || echo ""
+                sed -n 's/^PRETTY_NAME=//p' /etc/os-release 2>/dev/null | tr -d '"' || echo ""
                 ;;
         esac
     fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader PHP discovery/selection, DOMAIN_NAME support, improved domain validation, and automated SSL/vhost scaffolding across more OS families.
  * Installation summary saved securely (includes DB and WordPress credentials) and displayed at finish.

* **Bug Fixes**
  * Detects and aborts on existing WordPress installs; ensures install directory/extraction safety; reliable DB/user creation and credential cleanup on rollback.

* **Improvements**
  * Stricter execution and command checks, more robust Git and uncommitted-change handling, clearer OS-aware messaging and logging.

**Version:** 2.0.3
<!-- end of auto-generated comment: release notes by coderabbit.ai -->